### PR TITLE
feat: add signal_version to events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+SIGNAL_VERSION="v0.0.1"
 SERVICE_URL=""
 APPLICATION_NAME="example-app"
 PERFORMANCE_OBSERVER_METRICS="first-paint,first-contentful-paint,first-input-delay"

--- a/README.md
+++ b/README.md
@@ -57,10 +57,15 @@ cp .env.example .env
 The `.env` file contains the following values:
 
 ```bash
+SIGNAL_VERSION=""
 SERVICE_URL=""
 APPLICATION_NAME=""
 PERFORMANCE_OBSERVER_METRICS=""
 ```
+
+### Signal version (mandatory - pre-filled)
+
+Which version of the Signal snippet is currently running when sending the events
 
 ### Service url (mandatory)
 
@@ -175,14 +180,15 @@ By default each event is enhanced with the following metadata:
 
 ```js
 {
-  event_name,
-    user_agent,
-    google_analytics_client_id,
-    connection_type,
-    effective_connection_type,
-    url,
-    timestamp,
-    application;
+  signal_version;
+  event_name;
+  user_agent;
+  google_analytics_client_id;
+  connection_type;
+  effective_connection_type;
+  url;
+  timestamp;
+  application;
 }
 ```
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,7 @@ import strip from '@rollup/plugin-strip';
 import { terser } from 'rollup-plugin-terser';
 
 const {
+  VERSION,
   SERVICE_URL,
   APPLICATION_NAME,
   PERFORMANCE_OBSERVER_METRICS,
@@ -23,6 +24,7 @@ export default {
   ],
   plugins: [
     replace({
+      'process.env.SIGNAL_VERSION': JSON.stringify(SIGNAL_VERSION),
       'process.env.SERVICE_URL': JSON.stringify(SERVICE_URL),
       'process.env.APPLICATION_NAME': JSON.stringify(APPLICATION_NAME),
       'process.env.PERFORMANCE_OBSERVER_METRICS': JSON.stringify(

--- a/src/event.ts
+++ b/src/event.ts
@@ -22,6 +22,7 @@ export const enhance = (event: IRawMetric): IEnhancedMetric => {
 
   return {
     ...event,
+    signal_version: process.env.SIGNAL_VERSION || '',
     event_name: 'load performance tracking',
     user_agent: window.navigator.userAgent,
     google_analytics_client_id: getCookie('_ga'),

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -19,6 +19,7 @@ export interface IRawMetric {
 }
 
 export interface IEnhancedMetric extends IRawMetric {
+  signal_version: string | null;
   event_name: string;
   user_agent: string;
   google_analytics_client_id: string | null;


### PR DESCRIPTION
The `signal_version` field contains what's the current version of the snippet running in the client

## Purpose

To be able to properly point which snippet version is sending events

## Approach and changes

- [x] Add a new field for the event called `signal_version`; This field is picked up from the `.env` and has the default value in `.env.example`

## Definition of done

- [x] Development completed
- [ ] Reviewers assigned
- [x] Unit and integration tests
