### PR TITLE
Add missed major metrics to default config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 SERVICE_URL=""
 APPLICATION_NAME="example-app"
-PERFORMANCE_OBSERVER_METRICS="first-paint,first-contentful-paint,first-input-delay"
+PERFORMANCE_OBSERVER_METRICS="first-paint,first-contentful-paint,largest-contentful-paint,first-input-delay,time-to-interactive,cumulative-layout-shift,time-to-first-byte"


### PR DESCRIPTION
## Purpose

Make sure all important metrics are listed in default environment config to simplify build for those who installs the script first time.
